### PR TITLE
Fix wrong url

### DIFF
--- a/phoenicis-website-web/src/main/frontend/org/phoenicis/website/web/config/index.js
+++ b/phoenicis-website-web/src/main/frontend/org/phoenicis/website/web/config/index.js
@@ -2,7 +2,7 @@ var angular = require("angular");
 
 module.exports = {
     angularModule: angular.module("PhoenicisConfig", [])
-        .constant("PHOENICIS_API", "api/v5.0/")
+        .constant("PHOENICIS_API", "api/v5.0")
         .constant("ALLOWED_LOCALES", ["en", "fr"])
 
         .factory("CurrentLocale", ['$location', 'ALLOWED_LOCALES', function($location, ALLOWED_LOCALES) {


### PR DESCRIPTION
As PHOENICIS_API  is this "api/v5.0/", being the base url for API calls when called by other modules like for news it resolves to
"api/v5.0//news/:id" or for apps like "api/v5.0//apps/:id" etc.
Probable fix for #20